### PR TITLE
JS: config.default_language -> lang

### DIFF
--- a/templates/macros/javascript.html
+++ b/templates/macros/javascript.html
@@ -2,7 +2,7 @@
 <script src="{{ get_url(path="js/main.js") | safe }}" defer></script>
 {% if config.build_search_index %}
   <script src="{{ get_url(path="plugins/elasticlunr.min.js") | safe }}" defer></script>
-  <script src="{{ get_url(path="search_index." ~ config.default_language ~ ".js") | safe }}" defer></script>
+  <script src="{{ get_url(path="search_index." ~ lang ~ ".js") | safe }}" defer></script>
   <script src="{{ get_url(path="js/search.js") | safe }}" defer></script>
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
For some reason my configuration suddenly stop working with:
`config.default_language` not found in context while rendering

Similar problem found in some zola templates:
https://github.com/getzola/zola/issues/1442