### PR TITLE
darkmode: fallback to user-agent's "prefers-color-scheme"

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,7 +6,8 @@ document.getElementById('mode').addEventListener('click', () => {
   
 });
   
-if (localStorage.getItem('theme') === 'dark') {
+// enforce local storage setting but also fallback to user-agent preferences
+if (localStorage.getItem('theme') === 'dark' || (!localStorage.getItem('theme') && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
   
   document.body.classList.add('dark');
   


### PR DESCRIPTION
By falling back to the platform preference for the color-scheme[0] if
no local-storage key is set, we can improve user experience on first
load.

Use the widely available[1] `window.matchMedia` method to query that
preference in the fallback case.

While the `prefers-color-scheme` is relatively new, as browser support
appeared only ~2 years ago, it does not matter much here as older
browser will simply return a false match, thus the current theme
default is kept for them.

[0]: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
[1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia#browser_compatibility

Signed-off-by: Thomas Lamprecht <thomas@lamprecht.org>