### PR TITLE
Allow translating menus for multilanguage sites

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,10 @@ taxonomies = [
 # content for `default_language`.
 build_search_index = true
 
+[languages.fi]
+title="AdiDoks"
+
+
 [search]
 # Whether to include the title of the page/section in the index
 include_title = true
@@ -98,19 +102,6 @@ section = "blog" # see config.extra.main~url
 ## Sitelinks Search Box
 site_links_search_box = false
 
-
-# Menu items
-[[extra.menu.main]]
-name = "Docs"
-section = "docs"
-url = "/docs/getting-started/introduction/"
-weight = 10
-
-[[extra.menu.main]]
-name = "Blog"
-section = "blog"
-url = "/blog/"
-weight = 20
 
 [[extra.menu.social]]
 name = "Twitter"

--- a/content/_index.fi.md
+++ b/content/_index.fi.md
@@ -1,0 +1,51 @@
++++
+title = "Nykyaikainen teema dokumentaatiolle"
+
+
+# The homepage contents
+[extra]
+lead = '<b>AdiDoks</b> on nykyaikainen teema dokumentaatiosivustoille. Se on portattu Zolalle Hugo-teemasta nimeltä <a href="https://github.com/h-enk/">Doks</a>.'
+url = "/docs/getting-started/introduction/"
+url_button = "Aloita"
+repo_version = "GitHub v0.1.0"
+repo_license = "Open-source MIT License."
+repo_url = "https://github.com/aaranxu/adidoks"
+
+# Menu items
+[[extra.menu.main]]
+name = "Dokumentaatio"
+section = "docs"
+url = "/docs/getting-started/introduction/"
+weight = 10
+
+[[extra.menu.main]]
+name = "Blogi"
+section = "blog"
+url = "/blog/"
+weight = 20
+
+[[extra.list]]
+title = "Turvallisuustietoinen"
+content = 'Saat A+-arvosanoja <a href="https://observatory.mozilla.org/analyze/adidoks.org">Mozilla Observatoryssä</a> suoraan. Voit vaihtaa turvallisuusheadereita tarpeidesi mukaan.'
+
+[[extra.list]]
+title = "Salamannopea ⚡️"
+content = 'Saat hyvät pisteet <a href="https://googlechrome.github.io/lighthouse/viewer/?gist=7731347bb8ce999eff7428a8e763b637">Google Lighthousessa</a> defaultina. Doks poistaa tarpeettomat css:t, esinoutaa linkit, ja lataa kuvat laiskasti.'
+
+[[extra.list]]
+title = "SEO-valmis"
+content = "Käytä järkeviä oletusarvoja rakenteiselle datalle, open graphille ja Twitter-korteille. Tai muunna SEO-asetukset mieleisiksesi helposti."
+
+[[extra.list]]
+title = "Fulltext-haku"
+content = "Tee hakuja sivuillesi FlexSearchilla. Muuntele indeksointiasetuksia mieleisiksesi helposti."
+
+[[extra.list]]
+title = "Sivujen layoutit"
+content = "Rakenna sivuja laskeutumisivun, blogisivun tai dokumentaatiolayoutin mukaan. Lisää osioita ja komponentteja tarpeen mukaan."
+
+[[extra.list]]
+title = "Dark mode"
+content = "Vaihda hämärässä käytettävään käyttöliittymäteemaan nappia painamalla. Muuta värit muuttujilla vastaamaan brändiäsi."
+
++++

--- a/content/_index.md
+++ b/content/_index.md
@@ -11,6 +11,19 @@ repo_version = "GitHub v0.1.0"
 repo_license = "Open-source MIT License."
 repo_url = "https://github.com/aaranxu/adidoks"
 
+# Menu items
+[[extra.menu.main]]
+name = "Docs"
+section = "docs"
+url = "/docs/getting-started/introduction/"
+weight = 10
+
+[[extra.menu.main]]
+name = "Blog"
+section = "blog"
+url = "/blog/"
+weight = 20
+
 [[extra.list]]
 title = "Security aware"
 content = 'Get A+ scores on <a href="https://observatory.mozilla.org/analyze/adidoks.org">Mozilla Observatory</a> out of the box. Easily change the default Security Headers to suit your needs.'

--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -27,7 +27,19 @@
 		</ul>
 		<div class="collapse navbar-collapse order-4 order-md-1">
 			<ul class="navbar-nav main-nav me-auto order-5 order-md-2">
-				{% if config.extra.menu.main %}
+				{% if lang == config.default_language %}
+					{% set rootsectionpath = "_index.md" %}
+				{% else %}
+					{% set rootsectionpath = "_index." ~ lang ~ ".md" %}
+				{% endif %}
+				{% set mainsec = get_section(path=rootsectionpath) %}
+				{% if mainsec.extra.menu.main %}
+					{% for val in mainsec.extra.menu.main %}
+						<li class="nav-item{% if current_section == val.section %} {{ current_section }} active{% endif %}">
+							<a class="nav-link" href="{{ get_url(path=val.url, trailing_slash=true) | safe }}">{{ val.name }}</a>
+						</li>
+					{% endfor %}
+				{% elif config.extra.menu.main %}
 					{% for val in config.extra.menu.main %}
 						<li class="nav-item{% if current_section == val.section %} {{ current_section }} active{% endif %}">
 							<a class="nav-link" href="{{ get_url(path=val.url, trailing_slash=true) | safe }}">{{ val.name }}</a>


### PR DESCRIPTION
I made it possible to define main menu entries in `content/_index.md` for the default language and in `content/_index.lang.md` for translated pages in multilingual sites. I created an example Finnish translation as well.

Due to [issue in Zola](https://github.com/getzola/zola/issues/1442#issuecomment-933739278), this does not work in Zola 0.14.1. I am unable to test with an earlier version at the moment. Marking this PR as draft until it can be properly tested.

This functionality and logic could be easily extended to the footer menu as well.