### PR TITLE
Only capture arrow key events when search suggestions are visible

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -35,8 +35,11 @@ Source:
 document.addEventListener('keydown',suggestionFocus);
 
 function suggestionFocus(e){
-
   const focusableSuggestions= suggestions.querySelectorAll('a');
+  if (suggestions.classList.contains('d-none')
+      || focusableSuggestions.length === 0) {
+    return;
+  }
   const focusable= [...focusableSuggestions];
   const index = focusable.indexOf(document.activeElement);
 


### PR DESCRIPTION
The previous code unconditionally captured up and down arrow keys
for use in search result navigation. This change fixes this by making
the search code only capture arrow keys when search results are
visible and present.

The apparently redundant check for 'd-none' and focusableSuggestions
length is needed because suggestions can still exist when the user
enters a search term with matches but then clicks out of the search
box while leaving the search term in it.

Fixes #21