### PR TITLE
Page TOC indentation

### DIFF
--- a/sass/layouts/_sidebar.scss
+++ b/sass/layouts/_sidebar.scss
@@ -67,7 +67,7 @@ a.docs-link {
   padding-top: 0.375rem;
 }
 
-.page-links li ul li {
+.page-links ul ul li {
   border-top: none;
   padding-left: 1rem;
   margin-top: 0.125rem;


### PR DESCRIPTION
I suspect this stanza was meant to indent the lower headings in the TOC, but since it was `li ul li` and in the templates, they are directly nested as `ul ul li` not `ul li ul li`, the original selector didn't catch it - and it seems it didn't catch anything.