### PR TITLE
Fix: JavaScript stopped working on many browsers

### DIFF
--- a/templates/macros/javascript.html
+++ b/templates/macros/javascript.html
@@ -1,8 +1,8 @@
 {% macro javascript() %}
-<script type="javascript" src="{{ get_url(path="js/main.js") | safe }}" defer></script>
+<script type="text/javascript" src="{{ get_url(path="js/main.js") | safe }}" defer></script>
 {% if config.build_search_index %}
-  <script type="javascript" src="{{ get_url(path="plugins/elasticlunr.min.js") | safe }}" defer></script>
-  <script type="javascript" src="{{ get_url(path="search_index." ~ lang ~ ".js") | safe }}" defer></script>
-  <script type="javascript" src="{{ get_url(path="js/search.js") | safe }}" defer></script>
+  <script type="text/javascript" src="{{ get_url(path="plugins/elasticlunr.min.js") | safe }}" defer></script>
+  <script type="text/javascript" src="{{ get_url(path="search_index." ~ lang ~ ".js") | safe }}" defer></script>
+  <script type="text/javascript" src="{{ get_url(path="js/search.js") | safe }}" defer></script>
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
`"javascript"` isn't a valid value for the script tag's `type` attribute, so many browsers (tested on Firefox 96 and Chrome 97) will refuse to run it.

For me that meant the search and the dark/light button didn't work.

The fix is just to change `"javascript"` to `"text/javascript"`:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#javascript_types

cc @ziyouwa