### PR TITLE
Don't override zola syntax themes in dark mode

### DIFF
--- a/sass/common/_dark.scss
+++ b/sass/common/_dark.scss
@@ -191,7 +191,7 @@ body.dark pre code::-webkit-scrollbar-thumb {
   background: $border-dark;
 }
 
-body.dark code:not(.hljs) {
+body.dark pre:not(.hljs) {
   background: $body-overlay-dark;
   color: $body-color-dark;
 }


### PR DESCRIPTION
This works the same way as #24 by moving Adidoks' default code block
style to the `pre` level, not the `code` level where Zola works.

Fixes #42