### PR TITLE
fix: remove hardcoded section for docs & blog

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,12 @@
 {{ macros_head::resource() }}
 {{ macros_head::stylesheet() }}
 
+{% if current_path -%}
+  {% set current_section = current_path | split(pat="/") | nth(n=1) -%}
+{% else -%}
+  {% set current_section = '/' -%}
+{% endif -%}
+
 {% block seo %}
   {% if config.extra.title_separator %}
     {% set title_separator = " " ~ config.extra.title_separator ~ " " %}

--- a/templates/blog/page.html
+++ b/templates/blog/page.html
@@ -3,8 +3,6 @@
 {% extends "page.html" %}
 
 {% block seo %}
-  {# This value is matched by the config.extra.menu.main->section #}
-  {% set_global current_section = 'blog' %}
   {{ super() }}
 {% endblock seo %}
 

--- a/templates/docs/page.html
+++ b/templates/docs/page.html
@@ -5,8 +5,6 @@
 {% endblock body %}
 
 {% block header %}
-  {# This value is matched by the config.extra.menu.main~url #}
-  {% set current_section = "docs" %}
   {{ macros_header::header(current_section=current_section)}}
 {% endblock header %}
 

--- a/templates/docs/section.html
+++ b/templates/docs/section.html
@@ -5,8 +5,6 @@
 {% endblock body %}
 
 {% block header %}
-  {# This value is matched by the config.extra.menu.main~section #}
-  {% set current_section = "docs" %}
   {{ macros_header::header(current_section=current_section)}}
 {% endblock header %}
 


### PR DESCRIPTION
Hello,
Thanks for making this great theme available for zola.

This change allows reusing the blog & docs templates for other sections.
Related to #4.

I could not find any way to test the change other than navigating the sample site manually.
Do you have some cypress (or else) tests available ?