### PR TITLE
Fix Netlify Redirect

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://adidoks.netlify.com"
+base_url = "https://adidoks.netlify.app"
 title = "AdiDoks"
 description = "AdiDoks is a Zola theme helping you build modern documentation websites, which is a port of the Hugo theme Doks for Zola."
 


### PR DESCRIPTION
Netlify is redirecting all .com to .app, this is affecting the demo by making every link redirect, you can test by navigating pages on the current demo.

Also, feel free to add me as a maintainer to this theme if you need some help with approving good pull requests, etc.