### PR TITLE
feat: new option `extra.footer.nav.is_absolute_url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The following options should be under the `[extra]` in `config.toml`
 - `[[extra.menu.social]]` - the social links on the header of the page
 - `[extra.footer]` - the footer content on the left
 - `[[extra.footer.nav]]` - the footer navigations on the right
+  - `is_absolute_url` - whether to treat `url` as an absolute url (default to `false`, aka `url` is treated relatively)
 
 ### Templates
 

--- a/config.toml
+++ b/config.toml
@@ -129,4 +129,5 @@ weight = 10
 [[extra.footer.nav]]
 name = "Code of Conduct"
 url = "/docs/contributing/code-of-conduct/"
+is_absolute_url = false
 weight = 20

--- a/config.toml.example
+++ b/config.toml.example
@@ -140,4 +140,5 @@ weight = 10
 [[extra.footer.nav]]
 name = "Code of Conduct"
 url = "/docs/contributing/code-of-conduct/"
+is_absolute_url = false
 weight = 20

--- a/templates/macros/footer.html
+++ b/templates/macros/footer.html
@@ -15,7 +15,11 @@
 				<ul class="list-inline">
 					{% if config.extra.footer.nav %}
 						{% for val in config.extra.footer.nav %}
-							<li class="list-inline-item"><a href="{{ get_url(path=val.url, trailing_slash=true) | safe }}">{{ val.name }}</a></li>
+							{% if val.is_absolute_url %}
+								<li class="list-inline-item"><a href="{{ val.url | safe }}">{{ val.name }}</a></li>
+							{% else %}
+								<li class="list-inline-item"><a href="{{ get_url(path=val.url, trailing_slash=true) | safe }}">{{ val.name }}</a></li>
+							{% endif %}
 						{% endfor %}
 					{% endif %}
 				</ul>


### PR DESCRIPTION
This PR adds a new (optional boolean) option `extra.footer.nav.is_absolute_url`.  With its default value `false`, the current behavior is achieved. If set to `true`, the `extra.footer.nav.url` is treated as an absolute url hence used directly.

Resolves #32