### PR TITLE
fix: max-width: 100% on main images

### DIFF
--- a/sass/common/_global.scss
+++ b/sass/common/_global.scss
@@ -236,3 +236,8 @@ article {
     margin: 3rem 0;
   }
 }
+
+img {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
I'm not sure if this is the right solution, but large images overflow the main content region by default and this solves it. I applied this locally, but thought it might be useful to upstream.

Before:
<img width="1345" alt="image" src="https://github.com/aaranxu/adidoks/assets/41767/e6451653-65ae-457d-9c71-8b0604a43e79">

After:
<img width="1326" alt="image" src="https://github.com/aaranxu/adidoks/assets/41767/792dd4fd-a703-40d2-80ae-96707cf8fe35">
